### PR TITLE
chore: apply latest CircleCI config file from orbinoid documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, pr_build]
-    default: pr_build
+    enum: [release, standalone_release, standalone_release_replay, nexus_staging, vm_nexus_staging, pull_requests]
+    default: pull_requests
   dry_run:
     type: boolean
     default: true
@@ -15,49 +15,349 @@ parameters:
     description: "Maven ID of the Maven profile to use for a dry run ?"
   secrethub_org:
     type: string
-    default: "gravitee-lab"
+    default: "graviteeio"
     description: "SecretHub Org to use to fetch secrets ?"
   secrethub_repo:
     type: string
     default: "cicd"
     description: "SecretHub Repo to use to fetch secrets ?"
-
+  s3_bucket_name:
+    type: string
+    default: ''
+    description: "Name of the S3 Bucket used to store and retrieve the state of the maven project, to perform the nexus staging ?"
+  replayed_release:
+    type: string
+    default: ''
+    description: "What is the version number of the release you want to replay? (Mandatory, only for the 'standalone_release_replay' Workflow / see 'gio_action' pipeline parameter)"
 orbs:
-  gravitee: gravitee-io/gravitee@dev:1.0.4
+  slack: circleci/slack@4.2.1
+  gravitee: gravitee-io/gravitee@1.0
+  # gravitee: gravitee-io/gravitee@dev:1.0.4
+  secrethub: secrethub/cli@1.1.0
+  # secrethub: secrethub/cli@1.0.0
 
 workflows:
   version: 2.1
+  # -- typically this workflow is executed on pull requests events for Community Edition Gravitee Repositories
   pull_requests:
     when:
-      equal: [ pr_build, << pipeline.parameters.gio_action >> ]
+      and:
+        - equal: [ pull_requests, << pipeline.parameters.gio_action >> ]
     jobs:
-      - gravitee/pr-build:
+      - gravitee/d_pull_requests_secrets:
           context: cicd-orchestrator
+          name: pr_secrets_resolution
+      - gravitee/d_pull_requests_ce:
+          name: process_pull_request
+          requires:
+            - pr_secrets_resolution
+          # "What is the maven ID of the maven profile to use to build and deploy SNAPSHOTS to Prviate Artifactory ?"
+          maven_profile_id: 'gio-dev'
+          # nexus_snapshots_url: 'https://oss.sonatype.org/content/repositories/snapshots'
+          # nexus_snapshots_server_id: 'sonatype-nexus-snapshots'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'medium'
+            # filters:
+            # branches:
+            # ignore:
+          # - master
+  # ---
+  # The 2 Workflows Below are there for the CICD Orchestrator to be able to
+  # release Gravitee Kubernetes in an APIM release Process, with Docker executors instead of VMs
   release:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - not: << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_release_secrets:
           context: cicd-orchestrator
-          dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
+          name: release_secrets_resolution
+      - gravitee/d_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: false
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
   release_dry_run:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_release_secrets:
           context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: true
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+  # ---
+  # CICD Workflow For APIM Orchestrated Nexus Staging, Container-based : Circle CI Docker Executor
+  nexus_staging:
+    when:
+      equal: [ nexus_staging, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/d_nexus_staging_secrets:
+          context: cicd-orchestrator
+          name: nexus_staging_secrets_resolution
+      - gravitee/d_nexus_staging:
+          name: nexus_staging
+          requires:
+            - nexus_staging_secrets_resolution
           dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          # => If you are running a standalone release, your S3 Bucket name
+          #    is 'prepared-standalone-nexus-staging-${GRAVITEE_REPO_NAME}-${RELEASE_VERSION_NUMBER}'
+          # => If you are running an Orchestrated release, The Orchestrator knows how to compute the S3 Bucket name
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+  # ---
+  # The 6 Workflows Below are there to perform a "Standalone Release" and "replay" a "Standalone Release" :
+  # => independently of any APIM release Process, with Docker executors instead of VMs
+  # => with chained nexus staging : only when release with dry run mode off
+  standalone_release:
+    when:
+      and:
+        - equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+        - not: << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_release_secrets:
+          context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_standalone_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: false
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+  standalone_release_dry_run:
+    when:
+      and:
+        - equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+        - << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_release_secrets:
+          context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_standalone_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: true
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+  standalone_nexus_staging:
+    # ---
+    # Running the nexus staging makes sense only when the
+    # standalone release is being performed with dry run mode off
+    # That is to say, when the maven project is ready to be release to maven Staging
+    # ---
+    when:
+      and:
+        - equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+        - not: << pipeline.parameters.dry_run >>
+      # ---
+      # Running the nexus staging makes sense only when the
+      # standalone release is being performed with dry run mode off
+      # That is to say, when the maven project is ready to be release to mmaven Staging
+      # Never the less, to test the CICD system, I temporarily git pushed a different configuration
+      # ---
+      # when:
+      # equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/d_nexus_staging_secrets:
+          context: cicd-orchestrator
+          name: nexus_staging_secrets_resolution
+      - nexus_staging_dry_run_approval:
+          type: approval
+          requires:
+            - nexus_staging_secrets_resolution
+      - gravitee/d_standalone_nexus_staging:
+          name: standalone_nexus_staging_dry_run
+          requires:
+            - nexus_staging_dry_run_approval
+            # - nexus_staging_secrets_resolution
+          dry_run: true
+          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: "gravitee-release"
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+      - gravitee/d_standalone_nexus_staging:
+          name: standalone_nexus_staging
+          requires:
+            - standalone_nexus_staging_dry_run
+            # - nexus_staging_secrets_resolution
+          dry_run: false
+          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: "gravitee-release"
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+  standalone_release_replay:
+    when:
+      and:
+        - equal: [ standalone_release_replay, << pipeline.parameters.gio_action >> ]
+        - not: << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_release_secrets:
+          context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_standalone_release_replay:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: false
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          gio_release_version: << pipeline.parameters.replayed_release >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+  standalone_release_replay_dry_run:
+    when:
+      and:
+        - equal: [ standalone_release_replay, << pipeline.parameters.gio_action >> ]
+        - << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_release_secrets:
+          context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_standalone_release_replay:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: true
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          gio_release_version: << pipeline.parameters.replayed_release >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+  standalone_nexus_staging_replay:
+    # ---
+    # Running the nexus staging makes sense only when the
+    # standalone release is being performed with dry run mode off
+    # That is to say, when the maven project is ready to be release to maven Staging
+    # ---
+    when:
+      and:
+        - equal: [ standalone_release_replay, << pipeline.parameters.gio_action >> ]
+        - not: << pipeline.parameters.dry_run >>
+      # ---
+      # Running the nexus staging makes sense only when the
+      # standalone release is being performed with dry run mode off
+      # That is to say, when the maven project is ready to be release to mmaven Staging
+      # Never the less, to test the CICD system, I temporarily git pushed a different configuration
+      # ---
+      # when:
+      # equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/d_nexus_staging_secrets:
+          context: cicd-orchestrator
+          name: nexus_staging_secrets_resolution
+      - nexus_staging_replay_dry_run_approval:
+          type: approval
+          requires:
+            - nexus_staging_secrets_resolution
+      - gravitee/d_standalone_nexus_staging_replay:
+          name: standalone_nexus_staging_replay_dry_run
+          requires:
+            - nexus_staging_replay_dry_run_approval
+            # - nexus_staging_secrets_resolution
+          dry_run: true
+          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: "gravitee-release"
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          gio_release_version: << pipeline.parameters.replayed_release >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+      - gravitee/d_standalone_nexus_staging_replay:
+          name: standalone_nexus_staging_replay
+          requires:
+            - standalone_nexus_staging_replay_dry_run
+            # - nexus_staging_secrets_resolution
+          dry_run: false
+          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: "gravitee-release"
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          gio_release_version: << pipeline.parameters.replayed_release >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+
+  # ---
+  # CICD Workflow For APIM Orchestrated Nexus Staging, VM-based
+  vm_nexus_staging:
+    when:
+      equal: [ vm_nexus_staging, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/nexus_staging:
+          context: cicd-orchestrator
           secrethub_org: << pipeline.parameters.secrethub_org >>
           secrethub_repo: << pipeline.parameters.secrethub_repo >>
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+
+  # ---
+  # A nighlty release for all CE repositories
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - /^[0-999].[0-999].x/
+    jobs:
+      - gravitee/d_all_nightly_secrets:
+          context: cicd-orchestrator
+          name: nightly_secrets_resolution
+      - gravitee/d_all_nightly_ce:
+          name: process_pull_request
+          requires:
+            - nightly_secrets_resolution

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>17</version>
+        <version>17.2</version>
     </parent>
 
     <groupId>io.gravitee.notifier</groupId>


### PR DESCRIPTION
Based on: https://github.com/gravitee-io/gravitee-circleci-orbinoid/blob/develop/documentation/ref-config-yml/pure-docker-executor-based/gravitee-ce/dev-repos/config.yml

Also update pom parent as stated in https://github.com/gravitee-io/kb/wiki/CICD:-The-Gravitee-APIM-Release-Process#1-orchestrated-maven-and-git-release