### PR TITLE
fix: bump gravitee-bom to non alpha version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <version>1.4.2</version>
 
     <properties>
-        <gravitee-bom.version>4.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
         <gravitee-common.version>2.0.0</gravitee-common.version>
         <freemarker.version>2.3.32</freemarker.version>
 


### PR DESCRIPTION
**Issue**

N/A
**Description**

bump gravitee-bom to non alpha version
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.3-bump-gravitee-bom-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-api/1.4.3-bump-gravitee-bom-SNAPSHOT/gravitee-notifier-api-1.4.3-bump-gravitee-bom-SNAPSHOT.zip)
  <!-- Version placeholder end -->
